### PR TITLE
Add Sepolia

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,6 +30,7 @@ flametrace_performance = true
 "4" = { name = "ETHEREUM_RINKEBY", rpc_url = "https://rinkeby.infura.io/v3/YOUR_INFURA_PROJECT_ID", supported = false }
 "5" = { name = "ETH_GOERLI", rpc_url = "https://goerli.infura.io/v3/YOUR_PROJECT_ID", supported = false }
 "42" = { name = "ETHEREUM_KOVAN", rpc_url = "https://kovan.infura.io/v3/YOUR_INFURA_PROJECT_ID", supported = false }
+"11155111" = { name = "SEPOLIA_TESTNET", rpc_url = "https://rpc2.sepolia.org", supported = false }
 
 # Binance Smart Chain
 "56" = { name = "BSC_MAINNET", rpc_url = "https://bsc-dataseed.binance.org", supported = false }

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,0 +1,3 @@
+eth_account
+rlp
+web3

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,38 +1,37 @@
-mod util;
 mod structs;
+mod util;
 
 #[macro_use]
 extern crate lazy_static;
 
 use axum::{
     http::StatusCode,
-    Json,
     response::IntoResponse,
-    Router,
-    routing::{get, post}
+    routing::{get, post},
+    Json, Router,
 };
-use ethers::{
-    core::types::Bytes as EthBytes,
-    core::types::U256,
-};
+use ethers::{core::types::Bytes as EthBytes, core::types::U256};
 use reqwest;
 use serde_json::json;
 use std::collections::HashSet;
 use std::fs;
 use std::net::SocketAddr;
+use structs::{
+    BalanceRequestPayload, Config, EvmResponse, EvmRpcRequest, RpcError, TransactionRequest,
+};
 use toml;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info, instrument};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use structs::{BalanceRequestPayload, Config, EvmResponse, EvmRpcRequest, RpcError, TransactionRequest};
 use tracing_flame::FlameLayer;
-
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 // Constants
 lazy_static! {
     static ref CONFIG: Config = load_config();
     static ref SUPPORTED_CHAINS: HashSet<String> = {
-        CONFIG.chains.iter()
+        CONFIG
+            .chains
+            .iter()
             .filter_map(|(key, value)| {
                 if value.supported {
                     Some(key.clone())
@@ -45,12 +44,10 @@ lazy_static! {
 }
 
 fn load_config() -> Config {
-    let config_str = fs::read_to_string("config.toml")
-        .expect("Failed to read config.toml");
+    let config_str = fs::read_to_string("config.toml").expect("Failed to read config.toml");
     toml::from_str(&config_str).expect("Failed to parse config.toml")
 }
 // TODO utoipa and OpenApi docs
-
 
 #[tokio::main]
 async fn main() {
@@ -64,9 +61,13 @@ async fn main() {
             .init();
         info!("default tracing setup with flametrace performance DISABLED");
     }
+    info!("Configured support for {} chain(s)", SUPPORTED_CHAINS.len());
 
     let app = Router::new()
-        .route("/send_funding_and_user_signed_txns", post(send_funding_and_user_signed_txns))
+        .route(
+            "/send_funding_and_user_signed_txns",
+            post(send_funding_and_user_signed_txns),
+        )
         .route("/get_balance_for_account", get(get_balance_for_account))
         // See https://docs.rs/tower-http/0.1.1/tower_http/trace/index.html for more details.
         .layer(TraceLayer::new_for_http());
@@ -78,7 +79,6 @@ async fn main() {
         .await
         .unwrap();
 }
-
 
 fn setup_global_subscriber() -> impl Drop {
     let fmt_layer = tracing_subscriber::fmt::Layer::default();
@@ -92,12 +92,14 @@ fn setup_global_subscriber() -> impl Drop {
     _guard
 }
 
-
 #[instrument]
-async fn send_funding_and_user_signed_txns(Json(payload): Json<TransactionRequest>) -> impl IntoResponse {
+async fn send_funding_and_user_signed_txns(
+    Json(payload): Json<TransactionRequest>,
+) -> impl IntoResponse {
     info!("Received /send_funding_and_user_signed_txns request: {payload:#?}");
 
-    let funding_txn_raw: EthBytes = EthBytes::from(payload.raw_transactions[0].clone().into_bytes());
+    let funding_txn_raw: EthBytes =
+        EthBytes::from(payload.raw_transactions[0].clone().into_bytes());
     let user_txn_raw: EthBytes = EthBytes::from(payload.raw_transactions[1].clone().into_bytes());
     // TODO Post MVP return error if chain_id is None
     let chain_id: String = payload.chain_id.unwrap_or("97".to_string());
@@ -113,20 +115,26 @@ async fn send_funding_and_user_signed_txns(Json(payload): Json<TransactionReques
         jsonrpc: "2.0".to_string(),
         method: "eth_sendRawTransaction".to_string(),
         params: vec![funding_txn_raw.to_string()],
-        id: 1,  // if needed change id
+        id: 1, // if needed change id
     };
     info!("Sending Funding Transaction: {evm_funding_request:#?}");
 
     let client = reqwest::Client::new();
-    let evm_funding_http_response = match client.post(rpc_url.clone())
+    let evm_funding_http_response = match client
+        .post(rpc_url.clone())
         .json(&evm_funding_request)
         .send()
-        .await {
+        .await
+    {
         Ok(res) => res,
         Err(_) => {
             error!("Failed to parse EVM funding response");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "Failed to send EVM funding request").into_response();
-        },
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to send EVM funding request",
+            )
+                .into_response();
+        }
     };
 
     let evm_funding_response: EvmResponse = match evm_funding_http_response.json().await {
@@ -134,13 +142,13 @@ async fn send_funding_and_user_signed_txns(Json(payload): Json<TransactionReques
         Err(_) => {
             error!("Failed to parse funding response");
             return (StatusCode::BAD_REQUEST, "Failed to parse funding response").into_response();
-        },
+        }
     };
     info!("Funding Response: {evm_funding_response:#?}");
     if evm_funding_response.error.is_some() {
         let result: RpcError = evm_funding_response.error.unwrap();
         let result_str = json!(result).to_string();
-        return (StatusCode::BAD_REQUEST, result_str).into_response()
+        return (StatusCode::BAD_REQUEST, result_str).into_response();
     }
 
     // Send the second transaction (actual user txn)
@@ -148,28 +156,38 @@ async fn send_funding_and_user_signed_txns(Json(payload): Json<TransactionReques
         jsonrpc: "2.0".to_string(),
         method: "eth_sendRawTransaction".to_string(),
         params: vec![user_txn_raw.to_string()],
-        id: 1,  // if needed change id
+        id: 1, // if needed change id
     };
     info!("Sending User Transaction: {evm_user_txn_request:#?}");
 
     let client = reqwest::Client::new();
-    let response = match client.post(rpc_url.clone())
+    let response = match client
+        .post(rpc_url.clone())
         .json(&evm_user_txn_request)
         .send()
-        .await {
+        .await
+    {
         Ok(res) => res,
         Err(_) => {
             error!("Failed to parse user foreign chain txn response");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "Failed to send user foreign chain txn request").into_response();
-        },
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to send user foreign chain txn request",
+            )
+                .into_response();
+        }
     };
 
     let evm_user_txn_response: EvmResponse = match response.json().await {
         Ok(res) => res,
         Err(_) => {
             error!("Failed to parse user foreign chain txn response");
-            return (StatusCode::BAD_REQUEST, "Failed to parse user foreign chain txn response").into_response();
-        },
+            return (
+                StatusCode::BAD_REQUEST,
+                "Failed to parse user foreign chain txn response",
+            )
+                .into_response();
+        }
     };
     info!("User Foreign Chain Txn Response: {evm_user_txn_response:#?}");
     return if evm_user_txn_response.result.is_some() {
@@ -179,8 +197,7 @@ async fn send_funding_and_user_signed_txns(Json(payload): Json<TransactionReques
         let result: RpcError = evm_user_txn_response.error.unwrap();
         let result_str = json!(result).to_string();
         (StatusCode::BAD_REQUEST, result_str).into_response()
-    }
-
+    };
 }
 
 // TODO Post MVP remove
@@ -191,20 +208,26 @@ async fn get_balance_for_account(Json(payload): Json<BalanceRequestPayload>) -> 
         jsonrpc: "2.0".to_string(),
         method: "eth_getBalance".to_string(),
         params: vec![address.clone(), "latest".to_string()],
-        id: 1,  // if needed change id
+        id: 1, // if needed change id
     };
     info!("Balance Request: {evm_balance_request:#?}");
 
     let client = reqwest::Client::new();
-    let evm_balance_http_response = match client.post("https://data-seed-prebsc-1-s1.binance.org:8545")
+    let evm_balance_http_response = match client
+        .post("https://data-seed-prebsc-1-s1.binance.org:8545")
         .json(&evm_balance_request)
         .send()
-        .await {
+        .await
+    {
         Ok(res) => res,
         Err(_) => {
             error!("Failed to parse EVM balance response");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "Failed to send EVM balance request").into_response();
-        },
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to send EVM balance request",
+            )
+                .into_response();
+        }
     };
 
     let evm_balance_response: EvmResponse = match evm_balance_http_response.json().await {
@@ -212,7 +235,7 @@ async fn get_balance_for_account(Json(payload): Json<BalanceRequestPayload>) -> 
         Err(_) => {
             error!("Failed to parse response");
             return (StatusCode::BAD_REQUEST, "Failed to parse response").into_response();
-        },
+        }
     };
     // default to 0 balance if not found
     let hex_str: String = evm_balance_response.result.unwrap_or("0x0".to_string());

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
-
+use std::collections::HashMap;
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -10,11 +9,10 @@ pub struct Config {
 
 #[derive(Deserialize)]
 pub struct ChainConfig {
-    pub(crate) name: String,
+    // pub(crate) name: String,
     pub(crate) rpc_url: String,
     pub(crate) supported: bool,
 }
-
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct TransactionRequest {


### PR DESCRIPTION
This PR primarily adds sepolia to the example config (since this is where all the ETH devs are testing). Additionally, we ran `cargo fmt` and commented out an unused field in the Config struct. I recommend adding `cargo fmt --check` to the github CI file (but not part of this this PR).

