### PR TITLE
Add Requirements & Remove INFURA_KEY

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,12 +27,9 @@ flametrace_performance = true
 "bitcoin-testnet" = { name = "BITCOIN_TESTNET", rpc_url = "https://your-bitcoin-testnet-node.example.com", supported = false }
 
 # Ethereum Networks
-"1" = { name = "ETH_MAINNET", rpc_url = "https://mainnet.infura.io/v3/YOUR_PROJECT_ID", supported = true }
+"1" = { name = "ETH_MAINNET", rpc_url = "https://rpc.ankr.com/eth", supported = true }
 "11155111" = { name = "SEPOLIA_TESTNET", rpc_url = "https://rpc.sepolia.dev", supported = true }
-"3" = { name = "ETHEREUM_ROPSTEN", rpc_url = "https://ropsten.infura.io/v3/YOUR_INFURA_PROJECT_ID", supported = false }
-"4" = { name = "ETHEREUM_RINKEBY", rpc_url = "https://rinkeby.infura.io/v3/YOUR_INFURA_PROJECT_ID", supported = false }
-"5" = { name = "ETH_GOERLI", rpc_url = "https://goerli.infura.io/v3/YOUR_PROJECT_ID", supported = false }
-"42" = { name = "ETHEREUM_KOVAN", rpc_url = "https://kovan.infura.io/v3/YOUR_INFURA_PROJECT_ID", supported = false }
+"5" = { name = "ETH_GOERLI", rpc_url = "https://goerli.gateway.tenderly.co", supported = false }
 
 # Binance Smart Chain
 "56" = { name = "BSC_MAINNET", rpc_url = "https://bsc-dataseed.binance.org", supported = true }

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,0 +1,3 @@
+eth_account
+rlp
+web3

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,14 @@ mod util;
 
 #[macro_use]
 extern crate lazy_static;
-
 use axum::{
     http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
-use ethers::core::types::U256;
+use ethers::{core::types::Bytes as EthBytes, core::types::U256};
+use reqwest;
 use serde_json::json;
 use std::collections::HashSet;
 use std::fs;
@@ -18,6 +18,7 @@ use std::net::SocketAddr;
 use structs::{
     BalanceRequestPayload, Config, EvmResponse, EvmRpcRequest, RpcError, TransactionRequest,
 };
+use toml;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info, instrument};
 use tracing_flame::FlameLayer;
@@ -59,6 +60,7 @@ async fn main() {
             .init();
         info!("default tracing setup with flametrace performance DISABLED");
     }
+    info!("Configured support for {} chain(s)", SUPPORTED_CHAINS.len());
 
     let app = Router::new()
         .route(

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use ethers::{core::types::Bytes as EthBytes, core::types::U256};
-use reqwest;
+use ethers::core::types::U256;
 use serde_json::json;
 use std::collections::HashSet;
 use std::fs;
@@ -18,7 +17,6 @@ use std::net::SocketAddr;
 use structs::{
     BalanceRequestPayload, Config, EvmResponse, EvmRpcRequest, RpcError, TransactionRequest,
 };
-use toml;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info, instrument};
 use tracing_flame::FlameLayer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod util;
 
 #[macro_use]
 extern crate lazy_static;
+
 use axum::{
     http::StatusCode,
     response::IntoResponse,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+
 use std::collections::HashMap;
 
 #[derive(Deserialize)]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-
 use std::collections::HashMap;
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Following up on the accidentally closed "Add Sepolia" PR (https://github.com/near/multichain-relayer-server/pull/3). This adds requirements file to the integration test python scripts.

We also remove dead Ethereum testnets and include free tier node URLS (eliminating the need to supply `INFURA_KEY` env var).

For other networks, check out [Ankr](https://www.ankr.com/rpc/) - there are many free tier endpoints here.

A great place to find many many options for node urls is also here:

https://chainlist.org/

See for example [Ethereum Mainnet](https://chainlist.org/chain/1) options.