### PR TITLE
Integration test updates

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ flametrace_performance = true
 
 # Ethereum L2 Networks - Mainnets
 "42161" = { name = "ARBITRUM_ONE_MAINNET", rpc_url = "https://rpc.ankr.com/arbitrum", supported = true }
-"10" = { name = "OPTIMISM_MAINNET", rpc_url = "https://rpc.ankr.com/optimism", supported = false }
+"10" = { name = "OPTIMISM_MAINNET", rpc_url = "https://rpc.ankr.com/optimism", supported = true }
 "324" = { name = "ZKSYNC_MAINNET", rpc_url = "https://rpc.ankr.com/zksync_era", supported = false }
 "534352" = { name = "SCROLL_MAINNET", rpc_url = "https://rpc.ankr.com/scroll", supported = false }
 "238" = { name = "BLAST_MAINNET", rpc_url = "https://rpc.ankr.com/blast", supported = false }
@@ -17,7 +17,7 @@ flametrace_performance = true
 
 # Ethereum L2 Networks - Testnets
 "421614" = { name = "ARBITRUM_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/arbitrum_sepolia", supported = true }
-"11155420" = { name = "OPTIMISM_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/optimism_sepolia", supported = false }
+"11155420" = { name = "OPTIMISM_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/optimism_sepolia", supported = true }
 "300" = { name = "ZKSYNC_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/zksync_era_sepolia", supported = false }
 "534351" = { name = "SCROLL_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/scroll_sepolia_testnet", supported = false }
 "23888" = { name = "BLAST_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/blast_testnet_sepolia", supported = false }

--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,8 @@ flametrace_performance = true
 "zksync-mainnet" = { name = "ZKSYNC_MAINNET", rpc_url = "https://rpc.zksync.io", supported = false }
 "starknet-mainnet" = { name = "STARKNET_MAINNET", rpc_url = "https://starknet.io", supported = false }
 "loopring-mainnet" = { name = "LOOPRING_MAINNET", rpc_url = "https://rpc.loopring.io", supported = false }
+"base-testnet" = { name = "BASE_MAINNET", rpc_url = "https://rpc.ankr.com/base", supported = false }  # 8453
+
 
 # Ethereum L2 Networks - Testnets
 "421611" = { name = "ARBITRUM_RINKEBY", rpc_url = "https://rinkeby.arbitrum.io/rpc", supported = false }
@@ -19,6 +21,7 @@ flametrace_performance = true
 "zksync-testnet" = { name = "ZKSYNC_TESTNET", rpc_url = "https://rinkeby-api.zksync.io/jsrpc", supported = false }
 "starknet-testnet" = { name = "STARKNET_TESTNET", rpc_url = "https://goerli.starknet.io", supported = false }
 "loopring-testnet" = { name = "LOOPRING_TESTNET", rpc_url = "https://testnet.loopring.io", supported = false }
+"base-testnet" = { name = "BASE_TESTNET", rpc_url = "https://rpc.ankr.com/base_sepolia", supported = false }  # 84532
 
 # Solana Network
 "solana" = { name = "SOLANA_MAINNET", rpc_url = "https://api.mainnet-beta.solana.com", supported = false }

--- a/config.toml
+++ b/config.toml
@@ -7,21 +7,21 @@ flametrace_performance = true
 [chains]
 
 # Ethereum L2 Networks - Mainnets
-"42161" = { name = "ARBITRUM_ONE_MAINNET", rpc_url = "https://arb1.arbitrum.io/rpc", supported = false }
+"42161" = { name = "ARBITRUM_ONE_MAINNET", rpc_url = "https://rpc.ankr.com/arbitrum", supported = true }
 "10" = { name = "OPTIMISM_MAINNET", rpc_url = "https://mainnet.optimism.io", supported = false }
 "zksync-mainnet" = { name = "ZKSYNC_MAINNET", rpc_url = "https://rpc.zksync.io", supported = false }
 "starknet-mainnet" = { name = "STARKNET_MAINNET", rpc_url = "https://starknet.io", supported = false }
 "loopring-mainnet" = { name = "LOOPRING_MAINNET", rpc_url = "https://rpc.loopring.io", supported = false }
-"base-testnet" = { name = "BASE_MAINNET", rpc_url = "https://rpc.ankr.com/base", supported = false }  # 8453
+"8453" = { name = "BASE_MAINNET", rpc_url = "https://rpc.ankr.com/base", supported = true }
 
 
 # Ethereum L2 Networks - Testnets
-"421611" = { name = "ARBITRUM_RINKEBY", rpc_url = "https://rinkeby.arbitrum.io/rpc", supported = false }
+"421614" = { name = "ARBITRUM_SEPOLIA", rpc_url = "https://rpc.ankr.com/arbitrum_sepolia", supported = true }
 "69" = { name = "OPTIMISM_KOVAN", rpc_url = "https://kovan.optimism.io", supported = false }
 "zksync-testnet" = { name = "ZKSYNC_TESTNET", rpc_url = "https://rinkeby-api.zksync.io/jsrpc", supported = false }
 "starknet-testnet" = { name = "STARKNET_TESTNET", rpc_url = "https://goerli.starknet.io", supported = false }
 "loopring-testnet" = { name = "LOOPRING_TESTNET", rpc_url = "https://testnet.loopring.io", supported = false }
-"base-testnet" = { name = "BASE_TESTNET", rpc_url = "https://rpc.ankr.com/base_sepolia", supported = false }  # 84532
+"84532" = { name = "BASE_TESTNET", rpc_url = "https://rpc.ankr.com/base_sepolia", supported = true }
 
 # Solana Network
 "solana" = { name = "SOLANA_MAINNET", rpc_url = "https://api.mainnet-beta.solana.com", supported = false }

--- a/config.toml
+++ b/config.toml
@@ -8,19 +8,19 @@ flametrace_performance = true
 
 # Ethereum L2 Networks - Mainnets
 "42161" = { name = "ARBITRUM_ONE_MAINNET", rpc_url = "https://rpc.ankr.com/arbitrum", supported = true }
-"10" = { name = "OPTIMISM_MAINNET", rpc_url = "https://mainnet.optimism.io", supported = false }
-"zksync-mainnet" = { name = "ZKSYNC_MAINNET", rpc_url = "https://rpc.zksync.io", supported = false }
-"starknet-mainnet" = { name = "STARKNET_MAINNET", rpc_url = "https://starknet.io", supported = false }
-"loopring-mainnet" = { name = "LOOPRING_MAINNET", rpc_url = "https://rpc.loopring.io", supported = false }
+"10" = { name = "OPTIMISM_MAINNET", rpc_url = "https://rpc.ankr.com/optimism", supported = false }
+"324" = { name = "ZKSYNC_MAINNET", rpc_url = "https://rpc.ankr.com/zksync_era", supported = false }
+"534352" = { name = "SCROLL_MAINNET", rpc_url = "https://rpc.ankr.com/scroll", supported = false }
+"238" = { name = "BLAST_MAINNET", rpc_url = "https://rpc.ankr.com/blast", supported = false }
 "8453" = { name = "BASE_MAINNET", rpc_url = "https://rpc.ankr.com/base", supported = true }
 
 
 # Ethereum L2 Networks - Testnets
-"421614" = { name = "ARBITRUM_SEPOLIA", rpc_url = "https://rpc.ankr.com/arbitrum_sepolia", supported = true }
-"69" = { name = "OPTIMISM_KOVAN", rpc_url = "https://kovan.optimism.io", supported = false }
-"zksync-testnet" = { name = "ZKSYNC_TESTNET", rpc_url = "https://rinkeby-api.zksync.io/jsrpc", supported = false }
-"starknet-testnet" = { name = "STARKNET_TESTNET", rpc_url = "https://goerli.starknet.io", supported = false }
-"loopring-testnet" = { name = "LOOPRING_TESTNET", rpc_url = "https://testnet.loopring.io", supported = false }
+"421614" = { name = "ARBITRUM_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/arbitrum_sepolia", supported = true }
+"11155420" = { name = "OPTIMISM_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/optimism_sepolia", supported = false }
+"300" = { name = "ZKSYNC_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/zksync_era_sepolia", supported = false }
+"534351" = { name = "SCROLL_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/scroll_sepolia_testnet", supported = false }
+"23888" = { name = "BLAST_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/blast_testnet_sepolia", supported = false }
 "84532" = { name = "BASE_TESTNET", rpc_url = "https://rpc.ankr.com/base_sepolia", supported = true }
 
 # Solana Network
@@ -33,7 +33,7 @@ flametrace_performance = true
 
 # Ethereum Networks
 "1" = { name = "ETH_MAINNET", rpc_url = "https://rpc.ankr.com/eth", supported = true }
-"11155111" = { name = "SEPOLIA_TESTNET", rpc_url = "https://rpc.sepolia.dev", supported = true }
+"11155111" = { name = "ETH_SEPOLIA_TESTNET", rpc_url = "https://rpc.ankr.com/eth_sepolia", supported = true }
 "5" = { name = "ETH_GOERLI", rpc_url = "https://goerli.gateway.tenderly.co", supported = false }
 
 # Binance Smart Chain
@@ -41,9 +41,11 @@ flametrace_performance = true
 "97" = { name = "BSC_TESTNET", rpc_url = "https://data-seed-prebsc-1-s1.binance.org:8545", supported = true }
 
 # Polygon (MATIC) Networks
-"137" = { name = "POLYGON_MAINNET", rpc_url = "https://polygon-rpc.com/", supported = false }
-"80001" = { name = "MUMBAI_TESTNET", rpc_url = "https://rpc-mumbai.maticvigil.com", supported = false }
+"137" = { name = "POLYGON_MAINNET", rpc_url = "https://rpc.ankr.com/polygon", supported = false }
+"80002" = { name = "POLYGON_AMOY_TESTNET", rpc_url = "https://rpc.ankr.com/polygon_amoy", supported = false }
+"1101" = { name = "POLYGON_ZKEVM_MAINNET", rpc_url = "https://rpc.ankr.com/polygon_zkevm", supported = false }
+"2442" = { name = "POLYGON_ZKEVM_CARDONA_TESTNET", rpc_url = "https://rpc.ankr.com/polygon_zkevm_cardona", supported = false }
 
 # Avalanche Networks
-"43114" = { name = "AVAX_MAINNET", rpc_url = "https://api.avax.network/ext/bc/C/rpc", supported = false }
-"43113" = { name = "FUJI_TESTNET", rpc_url = "https://api.avax-test.network/ext/bc/C/rpc", supported = false }
+"43114" = { name = "AVAX_C_MAINNET", rpc_url = "https://rpc.ankr.com/avalanche-c", supported = false }
+"43113" = { name = "AVAX_FUJI_C_TESTNET", rpc_url = "https://rpc.ankr.com/avalanche_fuji-c", supported = false }

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -87,7 +87,7 @@ Instructions on how to manually perform end-to-end tests on the entire multichai
     ```shell
     near contract call-function as-transaction canhazgas.testnet \
       create_transaction json-args '{"transaction_rlp_hex":"eb80851bf08eb000825208947b965bdb7f0464843572eb2b8c17bdf27b720b14872386f26fc1000080808080","use_paymaster":true,"token_id":"<token_id>"}' \
-      prepaid-gas '100.000 TeraGas' attached-deposit '0.5 NEAR' \
+      prepaid-gas '100.000 TeraGas' attached-deposit '<deposit_in_near> NEAR' \
       sign-as <account_id>.testnet \
       network-config testnet sign-with-keychain send
     ```

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,6 +1,21 @@
-Instructions on how to manually perform end-to-end tests on the entire multichain relayer system including the gas station contract, indexer, and relayer server.  
+## Prerequisites
+You need to have the following installed:
+- Python >=3.10
+- Rust
+- [NEAR CLI-RS](https://github.com/near/near-cli-rs).
+    - Make sure to configure it with the correct network and account.
+
 # Run
-1.  The following instructions are only need to be called once to initialize the account on the gas station. Make sure to replace the `<account_id>` (string) with the account you want to initialize and `<token_id>` (integer) with the token id of the NFT you minted in step ii:
+ TODO
+
+## Manual Steps
+Instructions on how to manually perform end-to-end tests on the entire multichain relayer system including the gas station contract, indexer, and relayer server.
+
+
+
+### Run
+
+1.  The following instructions in 1.i-iii are only need to be called once to initialize the account on the gas station. Make sure to replace the `<account_id>` (string) with the account you want to initialize and `<token_id>` (integer) with the token id of the NFT you minted in step ii:
     1. Registration / Storage Deposit:
     ```shell
     near contract call-function as-transaction v2.nft.kagi.testnet \

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -6,15 +6,16 @@ You need to have the following installed:
     - Make sure to configure it with the correct network and account.
 
 # Run
+
+In separate terminals, run the following:
+- [gas station indexer](https://github.com/near/gas-station-event-indexer/tree/main) locally with the correct values in the `config.toml` file: `make run`
+- multichain server (this repo) is configured correctly (`config.toml`) and run: `cargo run`
+
 From root of multichain-relayer-server repo directory run: 
 ```
 python3 integration_tests/integration_test.py
 ```
 with the optional `--verbose` flag to print subprocess output.
-
-In separate terminals, run the following:
-- [gas station indexer](https://github.com/near/gas-station-event-indexer/tree/main) locally with the correct values in the `config.toml` file: `make run`
-- multichain server (this repo) is configured correctly (`config.toml`) and run: `cargo run`
 
 ## Manual Steps
 Instructions on how to manually perform end-to-end tests on the entire multichain relayer system including the gas station contract, indexer, and relayer server.

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -12,6 +12,10 @@ python3 integration_tests/integration_test.py
 ```
 with the optional `--verbose` flag to print subprocess output.
 
+In separate terminals, run the following:
+- [gas station indexer](https://github.com/near/gas-station-event-indexer/tree/main) locally with the correct values in the `config.toml` file: `make run`
+- multichain server (this repo) is configured correctly (`config.toml`) and run: `cargo run`
+
 ## Manual Steps
 Instructions on how to manually perform end-to-end tests on the entire multichain relayer system including the gas station contract, indexer, and relayer server.
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -69,8 +69,8 @@ Instructions on how to manually perform end-to-end tests on the entire multichai
     network-config testnet \
     sign-with-keychain send
     ```
-3. Update the transaction details of the EVM transaction you want to send in `generate_rlp_evm_txn.py` then run the script and save the RLP hex string output. 
-   1. If that doesn't work, try running the `generate_eip1559_rlp_hex()` test in tests/tests.rs - python and rust output different hex rlp excoded txns :/  
+3. Update the transaction details of the EVM transaction you want to send in `generate_eip1559_rlp_hex()` test in tests/tests.rs  then run the script and save the RLP hex string output. 
+   1. If that doesn't work, try running `generate_rlp_evm_txn.py` 
    
 4. Ensure the [gas station indexer](https://github.com/near/gas-station-event-indexer/tree/main) is running locally with the correct values in the `config.toml` file
 5. Ensure the multichain server is configured correctly (`config.toml`) and running: `cargo run`

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -6,7 +6,11 @@ You need to have the following installed:
     - Make sure to configure it with the correct network and account.
 
 # Run
- TODO
+From root of multichain-relayer-server repo directory run: 
+```
+python3 integration_tests/integration_test.py
+```
+with the optional `--verbose` flag to print subprocess output.
 
 ## Manual Steps
 Instructions on how to manually perform end-to-end tests on the entire multichain relayer system including the gas station contract, indexer, and relayer server.

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -77,7 +77,7 @@ Instructions on how to manually perform end-to-end tests on the entire multichai
    Example below:
     ```shell
     near contract call-function as-transaction canhazgas.testnet \
-      create_transaction json-args '{"transaction_rlp_hex":"eb80851bf08eb000825208947b965bdb7f0464843572eb2b8c17bdf27b720b14872386f26fc1000080808080","use_paymaster":true}' \
+      create_transaction json-args '{"transaction_rlp_hex":"eb80851bf08eb000825208947b965bdb7f0464843572eb2b8c17bdf27b720b14872386f26fc1000080808080","use_paymaster":true,"token_id":"<token_id>"}' \
       prepaid-gas '100.000 TeraGas' attached-deposit '0.5 NEAR' \
       sign-as <account_id>.testnet \
       network-config testnet sign-with-keychain send

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -11,10 +11,6 @@ You need to have the following installed:
 ## Manual Steps
 Instructions on how to manually perform end-to-end tests on the entire multichain relayer system including the gas station contract, indexer, and relayer server.
 
-
-
-### Run
-
 1.  The following instructions in 1.i-iii are only need to be called once to initialize the account on the gas station. Make sure to replace the `<account_id>` (string) with the account you want to initialize and `<token_id>` (integer) with the token id of the NFT you minted in step ii:
     1. Registration / Storage Deposit:
     ```shell
@@ -105,6 +101,8 @@ Instructions on how to manually perform end-to-end tests on the entire multichai
       network-config testnet \
       sign-with-keychain send
     ```
+   
+NOTE: this step will be updated soon, as support for yield/resume calls is implemented on MPC contract. 
 8. Watch the output of the gas station event indexer to see the transactions being emitted by the gas station contract.
 9. Watch the output of the multichain relayer server to see the transactions being sent to the foreign chain.
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,12 +1,26 @@
 Instructions on how to run end-to-end tests on the entire multichain relayer system.  
 # Run
-1. Update the transaction details of the EVM transaction you want to send in `generate_rlp_evm_txn.py` then run the script and save the RLP hex string output. 
+1.  The following instructions are only need to be called once to initialize the account on the gas station. Make sure to replace the `<account_id>` (string) with the account you want to initialize and `<token_id>` (integer) with the token id of the NFT you minted in step ii:
+    1. Registration / Storage Deposit:
+    ```shell
+    near contract call-function as-transaction v2.nft.kagi.testnet storage_deposit json-args {} prepaid-gas '100.0 Tgas' attached-deposit '1 NEAR' sign-as <account_id>.testnet network-config testnet sign-with-keychain send
+    ```
+    2. Mint NFT - make sure to save the token id from the logs of this call
+    ```shell
+    near contract call-function as-transaction v2.nft.kagi.testnet mint json-args {} prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' sign-as <account_id>.testnet network-config testnet sign-with-keychain send
+    ```
+    3. Approve the Gas Station for this Token
+    ```shell
+    near contract call-function as-transaction v2.nft.kagi.testnet ckt_approve_call json-args '{"token_id":"<token_id>","account_id":"canhazgas.testnet","msg":""}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' sign-as <account_id>.testnet network-config testnet sign-with-keychain send
+    ```
+2. TODO: get paymaster info from the gas station contract, then optionally manually set nonces
+3. Update the transaction details of the EVM transaction you want to send in `generate_rlp_evm_txn.py` then run the script and save the RLP hex string output. 
    1. If that doesn't work, try running the `generate_eip1559_rlp_hex()` test in tests/tests.rs - python and rust output different hex rlp excoded txns :/  
    
-2. Ensure the [gas station indexer](https://github.com/near/gas-station-event-indexer/tree/main) is running locally
-3. Ensure the multichain server is configured correctly (`config.toml`) and running: `cargo run`
+4. Ensure the [gas station indexer](https://github.com/near/gas-station-event-indexer/tree/main) is running locally
+5. Ensure the multichain server is configured correctly (`config.toml`) and running: `cargo run`
 
-4. Construct the signed transaction using the [near-cli-rs](https://github.com/near/near-cli-rs).
+6. Construct the signed transaction using the [near-cli-rs](https://github.com/near/near-cli-rs).
    The receiver account ID should be the gas station contract.
    You will need 2 actions if you want the gas station to cover your gas cost on the foreign chain:
    1 to send the NEAR equivalent and 1 function call to the gas station.
@@ -17,7 +31,7 @@ Instructions on how to run end-to-end tests on the entire multichain relayer sys
 ```shell
 near contract call-function as-transaction canhazgas.testnet create_transaction json-args '{"transaction_rlp_hex":"eb80851bf08eb000825208947b965bdb7f0464843572eb2b8c17bdf27b720b14872386f26fc1000080808080","use_paymaster":true}' prepaid-gas '100.000 TeraGas' attached-deposit '0.5 NEAR' sign-as nomnomnom.testnet network-config testnet sign-with-keychain send
 ```
-5. Get the `"id"` from the receipts from the call in step 4, and use that to call `sign_next` twice:
+7. Get the `"id"` from the receipts from the call in step 4, and use that to call `sign_next` twice:
 - `near contract call-function as-transaction canhazgas.testnet sign_next json-args '{"id":"16"}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as nomnomnom.testnet network-config testnet sign-with-keychain send`
 
 Optional for testing purposes:

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,23 +1,59 @@
-Instructions on how to run end-to-end tests on the entire multichain relayer system.  
+Instructions on how to manually perform end-to-end tests on the entire multichain relayer system including the gas station contract, indexer, and relayer server.  
 # Run
 1.  The following instructions are only need to be called once to initialize the account on the gas station. Make sure to replace the `<account_id>` (string) with the account you want to initialize and `<token_id>` (integer) with the token id of the NFT you minted in step ii:
     1. Registration / Storage Deposit:
     ```shell
-    near contract call-function as-transaction v2.nft.kagi.testnet storage_deposit json-args {} prepaid-gas '100.0 Tgas' attached-deposit '1 NEAR' sign-as <account_id>.testnet network-config testnet sign-with-keychain send
+    near contract call-function as-transaction v2.nft.kagi.testnet \
+      storage_deposit json-args {} prepaid-gas '100.0 Tgas' attached-deposit '1 NEAR' \ 
+      sign-as <account_id>.testnet network-config testnet sign-with-keychain send
     ```
     2. Mint NFT - make sure to save the token id from the logs of this call
     ```shell
-    near contract call-function as-transaction v2.nft.kagi.testnet mint json-args {} prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' sign-as <account_id>.testnet network-config testnet sign-with-keychain send
+    near contract call-function as-transaction v2.nft.kagi.testnet \ 
+      mint json-args {} prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' \
+      sign-as <account_id>.testnet network-config testnet sign-with-keychain send
     ```
     3. Approve the Gas Station for this Token
     ```shell
-    near contract call-function as-transaction v2.nft.kagi.testnet ckt_approve_call json-args '{"token_id":"<token_id>","account_id":"canhazgas.testnet","msg":""}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' sign-as <account_id>.testnet network-config testnet sign-with-keychain send
+    near contract call-function as-transaction v2.nft.kagi.testnet \
+      ckt_approve_call json-args '{"token_id":"<token_id>","account_id":"canhazgas.testnet","msg":""}' \
+      prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' \
+      sign-as <account_id>.testnet network-config testnet sign-with-keychain send
     ```
-2. TODO: get paymaster info from the gas station contract, then optionally manually set nonces
+2. Get paymaster info for the chain you want to send to from the gas station contract, then optionally manually set nonces:
+    ```shell
+    near contract call-function as-transaction canhazgas.testnet \
+     get_paymasters json-args '{"chain_id": "<chain_id>"}' \
+     prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' \
+     sign-as <account_id>.testnet network-config testnet sign-with-keychain send
+    ```
+   which  returns something like:
+    ```
+    --- Result -------------------------
+    [
+      {
+        "foreign_address": "0x98c6C99176911AD4E7fc7413eDF09956B2D7F0F8",
+        "minimum_available_balance": "99886599999948172000",
+        "nonce": 28,
+        "token_id": "1"
+      }
+    ]
+    ------------------------------------
+    ```
+   1. You may need to manually set the nonce for the paymaster to be able to send the transaction:
+   ```shell
+   near contract call-function as-transaction canhazgas.testnet \
+    get_paymasters json-args '{"chain_id": "<chain_id>"}' \
+    prepaid-gas '100.000 Tgas' \
+    attached-deposit '0 NEAR' \
+    sign-as <account_id>.testnet \
+    network-config testnet \
+    sign-with-keychain send
+    ```
 3. Update the transaction details of the EVM transaction you want to send in `generate_rlp_evm_txn.py` then run the script and save the RLP hex string output. 
    1. If that doesn't work, try running the `generate_eip1559_rlp_hex()` test in tests/tests.rs - python and rust output different hex rlp excoded txns :/  
    
-4. Ensure the [gas station indexer](https://github.com/near/gas-station-event-indexer/tree/main) is running locally
+4. Ensure the [gas station indexer](https://github.com/near/gas-station-event-indexer/tree/main) is running locally with the correct values in the `config.toml` file
 5. Ensure the multichain server is configured correctly (`config.toml`) and running: `cargo run`
 
 6. Construct the signed transaction using the [near-cli-rs](https://github.com/near/near-cli-rs).
@@ -28,13 +64,37 @@ Instructions on how to run end-to-end tests on the entire multichain relayer sys
    You also need to paste in the RLP generated hex for the EVM transaction you want on the other chain generated in step 1.
    When it asks you to send or display, choose send.
    Example below:
-```shell
-near contract call-function as-transaction canhazgas.testnet create_transaction json-args '{"transaction_rlp_hex":"eb80851bf08eb000825208947b965bdb7f0464843572eb2b8c17bdf27b720b14872386f26fc1000080808080","use_paymaster":true}' prepaid-gas '100.000 TeraGas' attached-deposit '0.5 NEAR' sign-as nomnomnom.testnet network-config testnet sign-with-keychain send
-```
-7. Get the `"id"` from the receipts from the call in step 4, and use that to call `sign_next` twice:
-- `near contract call-function as-transaction canhazgas.testnet sign_next json-args '{"id":"16"}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as nomnomnom.testnet network-config testnet sign-with-keychain send`
+    ```shell
+    near contract call-function as-transaction canhazgas.testnet \
+      create_transaction json-args '{"transaction_rlp_hex":"eb80851bf08eb000825208947b965bdb7f0464843572eb2b8c17bdf27b720b14872386f26fc1000080808080","use_paymaster":true}' \
+      prepaid-gas '100.000 TeraGas' attached-deposit '0.5 NEAR' \
+      sign-as <account_id>.testnet \
+      network-config testnet sign-with-keychain send
+    ```
+   which returns something like:
+    ```
+     --- Result -------------------------
+      {
+        "id": "29",
+        "pending_signature_count": 2
+      }
+      ------------------------------------
+     ```
+7. Get the `"id"` from the receipts from the result in the previous step, and use that to call `sign_next` twice:
+    ```shell
+    near contract call-function as-transaction canhazgas.testnet \
+      sign_next json-args '{"id":"<id>"}' \
+      prepaid-gas '300.0 Tgas' \
+      attached-deposit '0 NEAR' \
+      sign-as <account_id>.testnet \
+      network-config testnet \
+      sign-with-keychain send
+    ```
+8. Watch the output of the gas station event indexer to see the transactions being emitted by the gas station contract.
+9. Watch the output of the multichain relayer server to see the transactions being sent to the foreign chain.
 
-Optional for testing purposes:
+
+#### Optional for testing purposes:
 - Instead of creating the signed txn and calling the gas station contract to sign the transaction, you can get the recently signed transactions by calling: 
   - `near contract call-function as-read-only canhazgas.testnet list_signed_transaction_sequences_after json-args '{"block_height":"157111000"}' network-config testnet now` replacing the blockheight with a more recent blockheight
   - This will return something like the output below. Take an individual entry in the list of jsons and send that as the payload of a POST request to the `/send_funding_and_user_signed_txns` endpoint:

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -41,9 +41,10 @@ def send_signed_transactions(signed_transactions: List[str], chain_id: str):
         raise Exception("Failed to send raw transactions.")
 
 
-# Step 1: Get initial balance
-initial_balance = get_account_balance("0x48cf9dA81d8c9FE834093eCE58ea7221aBc19DB2")
-print("Initial balance:", initial_balance)
+# Step 1: run near rust cli to construct the transaction
+
+
+# Step 2: The indexer picks up the txn and calls the multichain-relayer-server
 
 # Step 2: Prepare and encode RLP transaction
 # paste this in from output of running `near` rust cli to construct the transaction
@@ -63,14 +64,3 @@ print("Near RPC Result:", json.dumps(near_rpc_result, indent=4))
 foreign_chain_tx_result = send_signed_transactions(near_rpc_result["signed_transactions"], near_rpc_result["chain_id"])
 print("Foreign Chain Tx Result:", foreign_chain_tx_result)
 
-# Step 5: Get updated balance
-updated_balance = get_account_balance("0x48cf9dA81d8c9FE834093eCE58ea7221aBc19DB2")
-print("Updated balance:", updated_balance)
-
-# Step 6: Compare balances and assert the condition
-# TODO :
-#  this integration test is outdated and only tests part of the flow
-#  either change the response format of get_balance_for_address or change the parsing of response
-# assert 0.01 < (initial_balance - updated_balance) / 10**18 < 0.015, "The balance difference does not match expected."
-
-print("Transaction processed successfully. Balance difference is within the expected range.")

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -1,116 +1,124 @@
-import subprocess
+import argparse
+import copy
 import json
+import subprocess
 import time
-import re
 
 
-def run_command(command):
+def run_command(command, verbose=False):
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     output, error = process.communicate()
-    return output.decode('utf-8'), error.decode('utf-8')
+    output_str = output.decode('utf-8')
+    error_str = error.decode('utf-8')
+    if verbose:
+        print("Command output:")
+        print(output_str)
+        if error_str:
+            print("Command error:")
+            print(error_str)
+    return output_str, error_str
 
 
-def initialize_account(account_id):
+def initialize_account(account_id, verbose=False):
     print(f"Initializing account {account_id}...")
 
     # Storage deposit
     cmd = f"""near contract call-function as-transaction v2.nft.kagi.testnet \
       storage_deposit json-args {{}} prepaid-gas '100.0 Tgas' attached-deposit '1 NEAR' \
       sign-as {account_id}.testnet network-config testnet sign-with-keychain send"""
-    output, error = run_command(cmd)
-    print("Storage deposit output:", output)
+    output, error = run_command(cmd, verbose)
+    print("Storage deposit completed.")
 
     # Mint NFT
     cmd = f"""near contract call-function as-transaction v2.nft.kagi.testnet \
       mint json-args {{}} prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' \
       sign-as {account_id}.testnet network-config testnet sign-with-keychain send"""
-    output, error = run_command(cmd)
-    print("Mint NFT output:", output)
+    output, error = run_command(cmd, verbose)
+    print("Mint NFT completed.")
 
     # Extract token_id from output
-    token_id_match = re.search(r'"token_id": "(\d+)"', output)
-    if token_id_match:
-        token_id = token_id_match.group(1)
-        print(f"Extracted token_id: {token_id}")
-    else:
-        raise Exception("Failed to extract token_id from mint output")
+    token_id: str = copy.deepcopy(output)
+    token_id = token_id.strip()
+    print(f"Extracted token_id: {token_id}")
 
     # Approve Gas Station for this Token
     cmd = f"""near contract call-function as-transaction v2.nft.kagi.testnet \
       ckt_approve_call json-args '{{"token_id":"{token_id}","account_id":"canhazgas.testnet","msg":""}}' \
-      prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' \
+      prepaid-gas '100.0 Tgas' attached-deposit '1 yoctoNEAR' \
       sign-as {account_id}.testnet network-config testnet sign-with-keychain send"""
-    output, error = run_command(cmd)
-    print("Approve Gas Station output:", output)
+    output, error = run_command(cmd, verbose)
+    print("Approve Gas Station completed.")
 
 
-def get_paymaster_info(account_id, chain_id):
+def get_paymaster_info(account_id, chain_id, verbose=False):
     print(f"Getting paymaster info for chain {chain_id}...")
     cmd = f"""near contract call-function as-transaction canhazgas.testnet \
      get_paymasters json-args '{{"chain_id": "{chain_id}"}}' \
      prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' \
      sign-as {account_id}.testnet network-config testnet sign-with-keychain send"""
-    output, error = run_command(cmd)
-    print("Paymaster info:", output)
+    output, error = run_command(cmd, verbose)
     return json.loads(output)
 
 
-def set_nonce(account_id, chain_id, nonce):
+def set_nonce(account_id, chain_id, nonce, verbose=False):
     print(f"Setting nonce for chain {chain_id} to {nonce}...")
     cmd = f"""near contract call-function as-transaction canhazgas.testnet \
      set_nonce json-args '{{"chain_id": "{chain_id}", "nonce": {nonce}}}' \
      prepaid-gas '100.000 Tgas' attached-deposit '0 NEAR' \
      sign-as {account_id}.testnet network-config testnet sign-with-keychain send"""
-    output, error = run_command(cmd)
-    print("Set nonce output:", output)
+    output, error = run_command(cmd, verbose)
+    print("Nonce set successfully.")
 
 
-def create_transaction(account_id, rlp_hex):
+def create_transaction(account_id, rlp_hex, verbose=False):
     print("Creating transaction...")
     cmd = f"""near contract call-function as-transaction canhazgas.testnet \
       create_transaction json-args '{{"transaction_rlp_hex":"{rlp_hex}","use_paymaster":true}}' \
       prepaid-gas '100.000 TeraGas' attached-deposit '0.5 NEAR' \
       sign-as {account_id}.testnet network-config testnet sign-with-keychain send"""
-    output, error = run_command(cmd)
-    print("Create transaction output:", output)
+    output, error = run_command(cmd, verbose)
     return json.loads(output)
 
 
-def sign_next(account_id, transaction_id):
+def sign_next(account_id, transaction_id, verbose=False):
     print(f"Signing transaction {transaction_id}...")
     cmd = f"""near contract call-function as-transaction canhazgas.testnet \
       sign_next json-args '{{"id":"{transaction_id}"}}' \
       prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' \
       sign-as {account_id}.testnet network-config testnet sign-with-keychain send"""
-    output, error = run_command(cmd)
-    print("Sign next output:", output)
+    output, error = run_command(cmd, verbose)
+    print("Transaction signed.")
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Run integration tests for the multichain relayer system.")
+    parser.add_argument("--verbose", action="store_true", help="Print subprocess output")
+    args = parser.parse_args()
+
     account_id = input("Enter your account ID (without .testnet): ")
     chain_id = input("Enter the chain ID: ")
     rlp_hex = input("Enter the RLP hex for the EVM transaction: ")
 
     # Initialize account
-    initialize_account(account_id)
+    initialize_account(account_id, args.verbose)
 
     # Get paymaster info
-    paymaster_info = get_paymaster_info(account_id, chain_id)
+    paymaster_info = get_paymaster_info(account_id, chain_id, args.verbose)
 
     # Set nonce if needed
     current_nonce = paymaster_info[0]['nonce']
     set_nonce_input = input(f"Current nonce is {current_nonce}. Do you want to set a new nonce? (y/n): ")
     if set_nonce_input.lower() == 'y':
         new_nonce = int(input("Enter the new nonce: "))
-        set_nonce(account_id, chain_id, new_nonce)
+        set_nonce(account_id, chain_id, new_nonce, args.verbose)
 
     # Create transaction
-    transaction = create_transaction(account_id, rlp_hex)
+    transaction = create_transaction(account_id, rlp_hex, args.verbose)
     transaction_id = transaction['id']
 
     # Sign transaction twice
     for _ in range(2):
-        sign_next(account_id, transaction_id)
+        sign_next(account_id, transaction_id, args.verbose)
         time.sleep(5)  # Wait a bit between signings
 
     print("Integration test completed. Check the gas station event indexer and multichain relayer server outputs.")

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -74,11 +74,11 @@ def set_nonce(account_id, chain_id, nonce, verbose=False):
     print("Nonce set successfully.")
 
 
-def create_transaction(account_id, rlp_hex, token_id, verbose=False):
+def create_transaction(account_id, rlp_hex, token_id, near_deposit, verbose=False):
     print("Creating transaction...")
     cmd = f"""near contract call-function as-transaction canhazgas.testnet \
       create_transaction json-args '{{"transaction_rlp_hex":"{rlp_hex}","use_paymaster":true,"token_id":"{token_id}"}}' \
-      prepaid-gas '100.000 TeraGas' attached-deposit '0.5 NEAR' \
+      prepaid-gas '100.000 TeraGas' attached-deposit '{near_deposit} NEAR' \
       sign-as {account_id}.testnet network-config testnet sign-with-keychain send"""
     output, error = run_command(cmd, verbose)
     return json.loads(output)
@@ -125,6 +125,9 @@ def main():
     rlp_hex = input("Enter the RLP hex for the EVM transaction (exclude 0x prefix): ")
     token_id = input("Enter the token ID (leave blank if you don't have one): ")
     skip_indexer: bool = input("Do you want to skip the indexer and send data directly to the endpoint? (y/n): ").lower().strip() == 'y'
+    near_deposit: float = float(
+        input("Enter the amount of NEAR to attach to the gas station transaction as payment for foreign chain gas: ")
+    )
 
     if token_id == "":
         # Initialize account
@@ -143,7 +146,7 @@ def main():
         set_nonce(account_id, chain_id, new_nonce, args.verbose)
 
     # Create transaction
-    transaction = create_transaction(account_id, rlp_hex, token_id, args.verbose)
+    transaction = create_transaction(account_id, rlp_hex, token_id, near_deposit, args.verbose)
     transaction_id = transaction['id']
 
     # Sign transaction twice

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -99,7 +99,7 @@ def main():
 
     account_id = input("Enter your account ID (without .testnet): ")
     chain_id = input("Enter the chain ID: ")
-    rlp_hex = input("Enter the RLP hex for the EVM transaction: ")
+    rlp_hex = input("Enter the RLP hex for the EVM transaction (exclude 0x prefix): ")
     token_id = input("Enter the token ID (leave blank if you don't have one): ")
 
     if token_id == "":


### PR DESCRIPTION
- [x] integration tests for calling gas station contract, picking up txn via indexer (optional - can also bypass by getting data from event logs in response (not guaranteed) then calling server), sending txn to server, calling foreign chain rpcs
- [x] Update integration test readme with automated run instructions
- [x] Update integration test readme manual run instructions
- [x] support for arbitrum, base, optimism
- [x] standardize EVM networks to use ankr RPC